### PR TITLE
Update Mixpanel API URL prompt label

### DIFF
--- a/main.go
+++ b/main.go
@@ -148,7 +148,7 @@ func main() {
 		apiUrlResult = os.Getenv("MIXPANEL_API_URL")
 	} else {
 		apiUrlPrompt := promptui.Prompt{
-			Label:     "Enter Mixpanel API URL",
+			Label:     "Enter Mixpanel API URL (for EU, use the EU-specific URL):",
 			AllowEdit: false,
 			Default:   "https://data.mixpanel.com/api/2.0",
 			Validate: func(input string) error {


### PR DESCRIPTION
When using the wrong API Url, you'll get this error:
https://github.com/stablecog/mixpanel-to-posthog/issues/1
Which is very unclear. Hopefully this saves some people time when they run into the same issue