### PR TITLE
Remove personal key requirement, more parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# SC Mixpanel to Posthog Data Migrator
+# SC Mixpanel to PostHog Data Migrator
 
-A tool for easily migrating data from [Mixpanel](https://mixpanel.com/) to [Posthog](https://posthog.com) (self-hosted or cloud)
+A tool for easily migrating data from [Mixpanel](https://mixpanel.com/) to [PostHog](https://posthog.com) (self-hosted or cloud)
 
 ## Disclaimer
 
-This is **NOT an official tool**. We are not affiliated with Posthog or Mixpanel
+This is **NOT an official tool**. We are not affiliated with PostHog or Mixpanel
 
-However, if you are looking to migrate from Mixpanel to Posthog like we were - we hope you find this tool useful.
+However, if you are looking to migrate from Mixpanel to PostHog like we were - we hope you find this tool useful.
 
 ## Setup
 
@@ -29,25 +29,23 @@ MIXPANEL_API_URL
 
 You can also put these in `.env` for convenience.
 
-### Posthog
+### PostHog
 
-You will need the following from Posthog:
+You will need the following from PostHog:
 
 - Project API key
-- Personal API key
 - Endpoint URL
 
 You will be prompted in CLI for these, but can also set them in the environment:
 
 ```
 POSTHOG_PROJECT_KEY=
-POSTHOG_API_KEY=
 POSTHOG_ENDPOINT=
 ```
 
 ## **WARNING** Do not use this without reading this first.
 
-The mixpanel export API has no pagination, the CLI will prompt you for a date range (required by Mixpanel)
+The Mixpanel export API has no pagination, the CLI will prompt you for a date range (required by Mixpanel)
 
 If you have a very large data set, **do not try to get it all at once**
 
@@ -63,7 +61,7 @@ Download the latest [Release](https://github.com/stablecog/sc-mp-to-ph/releases)
 
 The best way we found to migrate data is to do the following.
 
-1. Disable GeoIP app (if enabled)
+1. Disable GeoIP app in PostHog (if enabled)
 2. Import events (see below)
 3. In Mixpanel UI, export all users and columns as CSV
 4. Import the users (see below)

--- a/main.go
+++ b/main.go
@@ -40,18 +40,6 @@ func getPosthogClient() posthog.Client {
 		posthogApiKey = pR
 	}
 
-	var posthogPersonalApiKey string
-	if os.Getenv("POSTHOG_API_KEY") != "" {
-		posthogPersonalApiKey = os.Getenv("POSTHOG_API_KEY")
-	} else {
-		posthogApiKeyPrompt := promptui.Prompt{
-			Label: "Enter Posthog Personal API Key",
-			Mask:  '*',
-		}
-		pR, _ := posthogApiKeyPrompt.Run()
-		posthogPersonalApiKey = pR
-	}
-
 	// If in env, don't ask
 	var posthogEndpoint string
 	if os.Getenv("POSTHOG_ENDPOINT") != "" {
@@ -70,8 +58,7 @@ func getPosthogClient() posthog.Client {
 
 	// Create posthog client
 	posthogClient, err := posthog.NewWithConfig(posthogApiKey, posthog.Config{
-		Endpoint:       posthogEndpoint,
-		PersonalApiKey: posthogPersonalApiKey,
+		Endpoint: posthogEndpoint,
 	})
 	if err != nil {
 		color.Red("\nEncountered an error while creating Posthog client: %v", err)


### PR DESCRIPTION
I'm working on updating the Mixpanel to PostHog migration guide, so updating this tool along with it.

- Remove personal API key requirement (this is only required to use feature flags in Go) 
- Add more parsing to convert Mixpanel events and properties to the correct PostHog ones
- Slightly cleanup readme

Tested locally.